### PR TITLE
Fixed fetch revision for annotated git tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Reverse Chronological Order:
 
 ## master
+* Fixed fetch revision for annotated git tags. (@igorsokolov)
 * Fixed updating roles when custom user or port is specified. (@ayastreb)
 
 * `bin/` is not suggested to be in `linked_dirs` anymore (@kirs)

--- a/lib/capistrano/git.rb
+++ b/lib/capistrano/git.rb
@@ -40,7 +40,7 @@ class Capistrano::Git < Capistrano::SCM
     end
 
     def fetch_revision
-      context.capture(:git, "rev-parse --short #{fetch(:branch)}")
+      context.capture(:git, "rev-list --max-count=1 --abbrev-commit #{fetch(:branch)}")
     end
   end
 end


### PR DESCRIPTION
When you create git tag with annotation by doing : 

```
git tag -a <tag-name> -m "Message"
```

it creates new object. So 

```
git rev-parse <tag-name> 
```

returns the new commit SHA, while 

```
git rev-list --max-count=1 <tag-name>
```

returns the tagged commit SHA. 

--abbrev-commit - is for short commit SHA

So this change helps to keep track on correct revision when :branch is set to annotated tag name.

Thanks!
